### PR TITLE
Invalidate CloudFront cache after deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: node_js
 sudo: false
 node_js:
   - 8
+python:
+  - 3
 install:
   - npm install
+  # `awscli` is required for invalidation of CloudFront distributions.
+  - pip install awscli
 script: PUBLIC_URL=. npm run-script build
 deploy:
   provider: s3
@@ -17,3 +21,7 @@ deploy:
   cache_control: "max-age=300"
   on:
     branch: master
+after_deploy:
+  - aws configure set preview.cloudfront true
+  - test $TRAVIS_BRANCH = "master" && aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/redeem/*"
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 UI to exchange MKR tokens
 
+## Deployment
+
+Merge to `gh-pages` branch to deploy to production Github pages
+
+Merge to `master` to deploy to AWS S3/CloudFront as a backup
+
 ## Development
 
 Clone this project


### PR DESCRIPTION
Ethan reported a potential issue with caching. This will invalidate CloudFront cache after deploy.

TODO add CloudFront ID to repo's secrets.